### PR TITLE
Dusk to Pest Browser Tests Converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ public/assets/*.map
 /.nova
 tests/Browser/console
 tests/Browser/Screenshots
+
+tests/Browser/Screenshots

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -157,4 +157,6 @@ function formatParticipants($participants): array
     return $participants;
 }
 
+
+pest()->extend(Tests\TestCase::class)->in('Browser');
 pest()->extend(Tests\TestCase::class)->in('Browser');


### PR DESCRIPTION
This pull request includes the changes for converting your Laravel Dusk tests to Pest Browser Tests. Feel free to commit any additional changes to the `shift-163241` branch.

**Before merging**, you need to:

- Checkout the `shift-163241` branch
- Review **all** pull request comments for additional changes
- Run `composer update` (if the scripts fail, try with `--no-scripts`)
- Run `npm update`
- Run your browser tests `php artisan test`

If you get stuck, never hesitate to [email support](mailto:support@laravelshift.com). If you need more help with your upgrade, check out the [Human Shifts](https://laravelshift.com/human-shifts).
